### PR TITLE
Nave: Explicitly set NAVE_DIR

### DIFF
--- a/nave.sh
+++ b/nave.sh
@@ -93,14 +93,7 @@ get_nave_dir () {
   NAVEUA="nave/$(curl --version | head -n1)"
 
   if [ -z "${NAVE_DIR+defined}" ]; then
-    if [ -d "$XDG_CONFIG_HOME" ] && ! [ -d "$HOME/.nave" ]; then
-      NAVE_DIR="$XDG_CONFIG_HOME"/nave
-    elif [ -d "$HOME" ]; then
-      NAVE_DIR="$HOME"/.nave
-    else
-      local prefix=${PREFIX:-/usr/local}
-      NAVE_DIR=$prefix/lib/nave
-    fi
+    NAVE_DIR="/home/ifixit/.nave"
   fi
   NAVE_SRC="$NAVE_DIR/src"
   NAVE_ROOT="$NAVE_DIR/installed"


### PR DESCRIPTION
We run nave as many different users. Let's create a default nave dir 
of `/home/ifixit/.nave`. This will allow regular users and apache both 
to use the same directory.

By doing this, we can drop the `sudo -u apache make -B deps.runtime.node-upgrade`
from our [deploy scripts](https://github.com/iFixit/ifixit/blob/master/Exec/deployment/extensions.rb#L100) as well as on [machine boot](https://github.com/iFixit/server-templates/blob/master/shared/scripts/configure-apache#L22-L29). This will also
allow us to drop the custom logic to [find the nave directory in 
ImageLib](https://github.com/iFixit/ifixit/blob/master/Libs/ImageLib.php#L310-L339).

I think this will also let us drop the NAVE_DIR from the commonrc: https://github.com/iFixit/dotfiles/blame/ecac154a987811a097a899a7e6778c8e6bfba0ad/commonrc#L445

Connects: https://github.com/iFixit/ifixit/issues/47792

cc @djmetzle @andyg0808 